### PR TITLE
Fix doubled backslashes in saved output path on Windows

### DIFF
--- a/spritesheetgenerator/uispritesheetgenerator.py
+++ b/spritesheetgenerator/uispritesheetgenerator.py
@@ -228,7 +228,7 @@ class UISpritesheetGenerator(object):
 
         if outputPath.is_dir():
             # Save the directory so it can be auto-filled the next time the UI is opened.
-            self.settingsStorage.setValue(UISpritesheetGenerator.SETTINGS_PREV_OUTPUT_PATH_KEY, str(outputPath))
+            self.settingsStorage.setValue(UISpritesheetGenerator.SETTINGS_PREV_OUTPUT_PATH_KEY, os.path.normpath(str(outputPath)))
 
             # If the path is a directory, then append a very specific file name to avoid
             # accidentally overwriting any of the user's existing files.
@@ -239,7 +239,7 @@ class UISpritesheetGenerator(object):
                 outputPath = outputPath.with_suffix(".png")
 
             # Save the file path so it can be auto-filled the next time the UI is opened.
-            self.settingsStorage.setValue(UISpritesheetGenerator.SETTINGS_PREV_OUTPUT_PATH_KEY, str(outputPath))
+            self.settingsStorage.setValue(UISpritesheetGenerator.SETTINGS_PREV_OUTPUT_PATH_KEY, os.path.normpath(str(outputPath)))
 
         self.settingsStorage.sync()
 


### PR DESCRIPTION
On Windows, the output path saved to QSettings was being read back with doubled backslashes (e.g. C:\\Users\\...), causing the export to fail when attempting to write the file.

The fix normalizes the path string before saving it to `QSettings` using `os.path.normpath()`, which is a no-op on Unix so there should be no cross-platform impact.

Tested on Windows. Unable to test on Unix